### PR TITLE
Modify lesson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -69,4 +69,6 @@ client. The response is sent to the client through the web server.
 ## Conclusion
 
 We have learned about the MVC architecture and how it is implemented in Spring.
-In the next few lessons, we will building our own API with Spring Web.
+In the next few lessons, we will create our own API with the Spring Web
+dependency.
+

--- a/README.md
+++ b/README.md
@@ -66,33 +66,6 @@ Note that when we are building an API the View Resolver is not required. After
 step 5, the controller method returns the value that needs to be sent to the
 client. The response is sent to the client through the web server.
 
-## RESTful API
-
-REST (Representational State Transfer) is a common way of client-server
-interaction. It is a set of rules that define how data should be queried and
-managed. A service that is written with these rules is called a RESTful service.
-
-The following are the six principle of a RESTful service:
-
-- **Client-Server Interaction Model:** the application rendering the data and
-  the application processing the data are kept separate.
-- **Stateless:** Every request from a client must contain the necessary
-  information to retrieve or manipulate data on the server. It cannot rely on
-  any stored state on the server.
-- **Cacheable:** A request-response value can be cached on the server so that
-  the server can return repeated requests without having to reprocess data.
-- **Uniform Interface:** All RESTful services follow a consistent naming
-  convention which makes it easy to work across different services.
-- **Layered System:** The client request may be routed through other services
-  before reaching the server. A client doesn’t know if it is directly connected
-  to a server.
-- **Code on Demand:** A client can request executable code from the server in
-  the form of applets or scripts.
-
-Be sure to follow
-[REST resource naming conventions](https://restfulapi.net/resource-naming/) when
-building a RESTful service.
-
 ## Conclusion
 
 We have learned about the MVC architecture and how it is implemented in Spring.

--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ We have learned about the MVC architecture and how it is implemented in Spring.
 In the next few lessons, we will create our own API with the Spring Web
 dependency.
 
+## References
+
+-[Spring Web MVC Documentation](https://docs.spring.io/spring-framework/docs/3.2.x/spring-framework-reference/html/mvc.html)
+


### PR DESCRIPTION
This change is being made in the consumer canvas per the conversation on 7/22 to keep the same modules for Blackrock and AWS to streamline.

- Remove the RESTful API section and put it in the Review REST lesson.
- Fix typo in the conclusion.